### PR TITLE
take depth encoding from message

### DIFF
--- a/src/python/director/segmentation.py
+++ b/src/python/director/segmentation.py
@@ -20,6 +20,7 @@ from director.filterUtils import *
 from director.fieldcontainer import FieldContainer
 from director.segmentationroutines import *
 from director import cameraview
+from director import drcargs
 import vtkDRCFiltersPython as drc
 
 from thirdparty import qhull_2d
@@ -175,12 +176,23 @@ class DisparityPointCloudItem(vis.PolyDataItem):
         self.addProperty('Target FPS', 5.0, attributes=om.PropertyAttributes(decimals=1, minimum=0.1, maximum=30.0, singleStep=0.1))
         self.addProperty('Max Range', 5.0,  attributes=om.PropertyAttributes(decimals=2, minimum=0., maximum=30.0, singleStep=0.25))
 
+        isSimulation = drcargs.getDirectorConfig()['simulation']
         self.reader = drc.vtkRosDepthImageSubscriber()
-        if cameraName == 'REALSENSE_FORWARD_CAMERA_LEFT':
-            self.reader.Start('/realsense_d435_forward/color/image_raw', 'compressed', '/realsense_d435_forward/color/camera_info',
-                              '/realsense_d435_forward/aligned_depth_to_color/image_raw', 'compressedDepth', '/realsense_d435_forward/aligned_depth_to_color/camera_info')
+        if (isSimulation == 'True'):
+            #print "cameras in sim"
+            if cameraName == 'REALSENSE_FORWARD_CAMERA_LEFT':
+                self.reader.Start('/realsense_d435_forward/rgb/image_raw', 'raw', '/realsense_d435_forward/rgb/camera_info',
+                                  '/realsense_d435_forward/depth/image_raw', 'raw', '/realsense_d435_forward/depth/camera_info')
+            else:
+                self.reader.Start('/realsense_d435/rgb/image_raw', 'raw', '/realsense_d435/rgb/camera_info',
+                                  '/realsense_d435/depth/image_raw', 'raw', '/realsense_d435/depth/camera_info')
         else:
-            self.reader.Start('/realsense_d435/color/image_raw', 'compressed', '/realsense_d435/color/camera_info',
+            #print "cameras not in sim, real operation"
+            if cameraName == 'REALSENSE_FORWARD_CAMERA_LEFT':
+                self.reader.Start('/realsense_d435_forward/color/image_raw', 'compressed', '/realsense_d435_forward/color/camera_info',
+                                  '/realsense_d435_forward/aligned_depth_to_color/image_raw', 'compressedDepth', '/realsense_d435_forward/aligned_depth_to_color/camera_info')
+            else:
+                self.reader.Start('/realsense_d435/color/image_raw', 'compressed', '/realsense_d435/color/camera_info',
                               '/realsense_d435/aligned_depth_to_color/image_raw', 'compressedDepth', '/realsense_d435/aligned_depth_to_color/camera_info')
 
         decimation = int(self.properties.getPropertyEnumValue('Decimation'))

--- a/src/vtk/DRCFilters/depthImageUtils.h
+++ b/src/vtk/DRCFilters/depthImageUtils.h
@@ -29,7 +29,7 @@ public:
                    pcl::PointCloud<pcl::PointXYZRGB>::Ptr &cloud);
 
   void unpackMultisense(const uint8_t* depth_data, const uint8_t* color_data, int h, int w, cv::Mat_<double> repro_matrix,
-                        pcl::PointCloud<pcl::PointXYZRGB>::Ptr &cloud, bool is_rgb = true, int depth_type = 0);
+                        pcl::PointCloud<pcl::PointXYZRGB>::Ptr &cloud, bool is_rgb = true, std::string depth_encoding = "Unknown");
 
   void SetDecimate(int decimate);
 


### PR DESCRIPTION
@benoit-robotics : we discussed that some depth data is in mm and some are in m:

- simulated depth from gazebo is encoded in m and called '32fc1'. 4 byte float
- real depth from the realsense is encoded in mm and called '16uc1'. 2 byte short

this implements the switch using the encoding variable in the images