### PR TITLE
store the message checksum and pass it to the python layer

### DIFF
--- a/src/app/wrapped_methods_ros.txt
+++ b/src/app/wrapped_methods_ros.txt
@@ -11,3 +11,4 @@ ddROSSubscriber::ddROSSubscriber(const QString&);
 ddROSSubscriber::ddROSSubscriber(const QString&, QObject*);
 QString ddROSSubscriber::channel() const;
 void ddROSSubscriber::setSpeedLimit(double);
+void ddROSSubscriber::unsubscribe();


### PR DESCRIPTION
also implements a methods to unsubscribe from a topic. this is used
on the python layer to unsubscribe then the msg checksum doesnt match the
decoder/current checksum