### PR TITLE
Draw aicp poses in director

### DIFF
--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -86,6 +86,7 @@ set(python_files
   director/otdfmodel.py
   director/outputconsole.py
   director/packagepath.py
+  director/pathdrawer.py
   director/perception.py
   director/planningutils.py
   director/planplayback.py

--- a/src/python/director/pathdrawer.py
+++ b/src/python/director/pathdrawer.py
@@ -1,0 +1,41 @@
+import director.objectmodel as om
+import director.rosutils as rosutils
+from director import tfdrawer as tf_draw
+
+from nav_msgs.msg import Path
+
+class AicpPoseSource(om.ContainerItem):
+
+    def __init__(self, name, topicName, fixedFrame):
+        om.ContainerItem.__init__(self, name)
+
+        self.topicName = topicName
+        self.subscriber = rosutils.addSubscriber(self.topicName, Path, self._posesCallback)
+        self.tfDrawer = tf_draw.TfDrawer(fixedFrame)
+        self.objects = [] # objects drawn by this class
+
+        self.addProperty('Topic name', topicName)
+        self.addProperty('Subscribe', True)
+        self.addProperty('Visible', True)
+
+
+    def _posesCallback(self, msg):
+
+        for i, pose in enumerate(msg.poses):
+            transform = rosutils.rosPoseToTransform(pose.pose)
+            self.tfDrawer.drawFrame(transform, "pose " + str(i), msg.header.stamp, msg.header.frame_id,
+                                    parent=self)
+
+    def _onPropertyChanged(self, propertySet, propertyName):
+        om.ContainerItem._onPropertyChanged(self, propertySet, propertyName)
+
+        if propertyName == 'Topic name':
+            self.topicName = self.getProperty(propertyName)
+            if self.getProperty('Subscribe'):
+                self.subscriber = rosutils.addSubscriber(self.topicName, Path, self._posesCallback)
+        elif propertyName == 'Subscribe':
+            if self.getProperty(propertyName):
+                self.subscriber = rosutils.addSubscriber(self.topicName, Path, self._posesCallback)
+            else:
+                self.subscriber = None
+

--- a/src/python/director/pathdrawer.py
+++ b/src/python/director/pathdrawer.py
@@ -6,7 +6,7 @@ import director.applogic as app
 from nav_msgs.msg import Path
 
 
-class AicpPoseSource(om.ContainerItem):
+class PathSource(om.ContainerItem):
 
     def __init__(self, name, topicName, tfDrawer):
         om.ContainerItem.__init__(self, name)
@@ -31,23 +31,22 @@ class AicpPoseSource(om.ContainerItem):
 
     def _posesCallback(self, msg):
         view = app.getCurrentRenderView()
+        name = self.getProperty('Name')
         #only render last poses received
-
-        print len(msg.poses)-self.prevIndexReceived
 
         for i in range(self.prevIndexReceived+1, len(msg.poses)):
             pose = msg.poses[i]
 
             transform = rosutils.rosPoseToTransform(pose.pose)
-            tfFrame = self.tfDrawer.drawFrame(transform, "pose " + str(i), msg.header.stamp, msg.header.frame_id,
+            tfFrame = self.tfDrawer.drawFrame(transform, name + " - pose " + str(i), msg.header.stamp, msg.header.frame_id,
                                     parent=self)
             self.frames.append(tfFrame)
-            tfArrow = self.tfDrawer.drawArrow(transform, "arrow " + str(i), msg.header.stamp, msg.header.frame_id,
+            tfArrow = self.tfDrawer.drawArrow(transform, name + " - arrow " + str(i), msg.header.stamp, msg.header.frame_id,
                                               parent=self)
             self.arrows.append(tfArrow)
 
             if self.prevTfFrame:
-                line = tf_draw.LineItem('line ' + str(i), self.prevTfFrame, tfFrame)
+                line = tf_draw.LineItem(name + ' - line ' + str(i), self.prevTfFrame, tfFrame)
                 line.addToView(view)
                 om.addToObjectModel(line, self.lineContainer)
                 self.lines.append(line)

--- a/src/python/director/pathdrawer.py
+++ b/src/python/director/pathdrawer.py
@@ -1,6 +1,7 @@
 import director.objectmodel as om
 import director.rosutils as rosutils
 from director import tfdrawer as tf_draw
+import director.applogic as app
 
 from nav_msgs.msg import Path
 
@@ -9,22 +10,46 @@ class AicpPoseSource(om.ContainerItem):
     def __init__(self, name, topicName, fixedFrame):
         om.ContainerItem.__init__(self, name)
 
+        om.addToObjectModel(self)
         self.topicName = topicName
         self.subscriber = rosutils.addSubscriber(self.topicName, Path, self._posesCallback)
         self.tfDrawer = tf_draw.TfDrawer(fixedFrame)
-        self.objects = [] # objects drawn by this class
+        self.lines = []
+        self.frames = []
+        self.lineContainer = om.getOrCreateContainer('lines', parentObj=self)
 
         self.addProperty('Topic name', topicName)
         self.addProperty('Subscribe', True)
         self.addProperty('Visible', True)
+        self.addProperty('Draw Lines', True)
+        self.addProperty('Draw Frames', True)
 
 
     def _posesCallback(self, msg):
 
+        view = app.getCurrentRenderView()
+
+        # clear lines and frames
+        for line in self.lines:
+            line.disconnect()
+        del self.lines[:]
+        del self.frames[:]
+
+
+        prevTfFrame = None
         for i, pose in enumerate(msg.poses):
             transform = rosutils.rosPoseToTransform(pose.pose)
-            self.tfDrawer.drawFrame(transform, "pose " + str(i), msg.header.stamp, msg.header.frame_id,
+            tfFrame = self.tfDrawer.drawFrame(transform, "pose " + str(i), msg.header.stamp, msg.header.frame_id,
                                     parent=self)
+            self.frames.append(tfFrame)
+
+            if prevTfFrame:
+                line = tf_draw.LineItem('line ' + str(i), prevTfFrame, tfFrame)
+                line.addToView(view)
+                om.addToObjectModel(line, self.lineContainer)
+                self.lines.append(line)
+            prevTfFrame = tfFrame
+
 
     def _onPropertyChanged(self, propertySet, propertyName):
         om.ContainerItem._onPropertyChanged(self, propertySet, propertyName)
@@ -38,4 +63,14 @@ class AicpPoseSource(om.ContainerItem):
                 self.subscriber = rosutils.addSubscriber(self.topicName, Path, self._posesCallback)
             else:
                 self.subscriber = None
+        elif propertyName == 'Draw Lines':
+            for line in self.lines:
+                line.setProperty('Visible', self.getProperty(propertyName))
+        elif propertyName == 'Draw Frames':
+            for frame in self.frames:
+                frame.setProperty('Visible', self.getProperty(propertyName))
+        elif propertyName == 'Visible':
+            self.setProperty('Draw Lines', self.getProperty(propertyName))
+            self.setProperty('Draw Frames', self.getProperty(propertyName))
+
 

--- a/src/python/director/tfdrawer.py
+++ b/src/python/director/tfdrawer.py
@@ -3,6 +3,37 @@ from director import visualization as vis
 from director.debugVis import DebugData
 from director import objectmodel as om
 
+import vtk
+
+
+class LineItem(vis.PolyDataItem):
+    def __init__(self, name, tfFrame1, tfFrame2):
+        vis.PolyDataItem.__init__(self, name, vtk.vtkPolyData(), view=None)
+        self.tfFrame1 = tfFrame1
+        self.tfFrame2 = tfFrame2
+        self.callbackId1 = tfFrame1.connectTransformModified(self.redraw())
+        self.callbackId2 = tfFrame2.connectTransformModified(self.redraw())
+        self.draw()
+
+    def draw(self):
+        d = DebugData()
+        p1 = self.tfFrame1.transform.GetPosition()
+        p2 = self.tfFrame2.transform.GetPosition()
+        d.addLine(p1, p2, color=[0, 1, 0])
+        polyData = d.getPolyData()
+        self.setPolyData(polyData)
+        self.setProperty('Color By', 'RGB255')
+
+    def disconnect(self):
+        self.tfFrame1.disconnectCallback(self.callbackId1)
+        self.tfFrame2.disconnectCallback(self.callbackId2)
+
+    def redraw(self):
+        #callback called when a TfFrame1 or TfFrame2 is modified
+        self.draw()
+
+
+
 class TfDrawer(object):
 
     def __init__(self, frame):

--- a/src/python/director/tfdrawer.py
+++ b/src/python/director/tfdrawer.py
@@ -16,8 +16,11 @@ class PolyDataTfObserver(vis.PolyDataItem):
         vis.PolyDataItem.__init__(self, name, vtk.vtkPolyData(), view=None)
         self.tfFrame1 = tfFrame1
         self.tfFrame2 = tfFrame2
-        self.callbackId1 = tfFrame1.connectTransformModified(self.draw())
-        self.callbackId2 = tfFrame2.connectTransformModified(self.draw())
+        self.callbackId1 = tfFrame1.connectTransformModified(self.callback)
+        self.callbackId2 = tfFrame2.connectTransformModified(self.callback)
+        self.draw()
+
+    def callback(self, item):
         self.draw()
 
     @abc.abstractmethod

--- a/src/python/director/tfvisualization.py
+++ b/src/python/director/tfvisualization.py
@@ -463,6 +463,7 @@ class TfPolyDataItem(TfMovableItem):
         transformFilter.Update()
 
         vis.PolyDataItem.setPolyData(self, transformFilter.GetOutput())
+        self.callbacks.process('TransformModified', self)
 
     def setPolyData(self, polyData):
         #self._notTransformedPolyData = polyData

--- a/src/python/director/tfvisualization.py
+++ b/src/python/director/tfvisualization.py
@@ -202,7 +202,7 @@ class TfFrameSync(object):
         if baseItemToRemove.frame in self.baseItemsToUpdate:
             self.baseItemsToUpdate.remove(baseItem)
 
-        item.disconnectItemModified(self.items[itemId].callbackId)
+        item.disconnectCallback(self.items[itemId].callbackId)
         item._frameSync = None
         self._removeItemId(itemId)
 
@@ -247,6 +247,7 @@ class TfMovableItem(vis.PolyDataItem):
 
         vis.PolyDataItem.__init__(self, name, polyData, view)
 
+        # localTransform is the transform of the item in frame
         self.localTransform = transformUtils.copyFrame(transform)
         self._blockSignals = False
         self._frameSync = None
@@ -254,13 +255,23 @@ class TfMovableItem(vis.PolyDataItem):
         self.frame = frame
 
         self.callbacks.addSignal('ItemModified')
+        self.callbacks.addSignal('TransformModified')
         self.observerTag = None
 
 
     def connectItemModified(self, func):
+        """
+        This signal *ItemModified* is triggered when the local transform of the item is modified
+        """
         return self.callbacks.connect('ItemModified', func)
 
-    def disconnectItemModified(self, callbackId):
+    def connectTransformModified(self, func):
+        """
+        This signal *TransformModified* is triggered when the global transform of the item is modified
+        """
+        return self.callbacks.connect('TransformModified', func)
+
+    def disconnectCallback(self, callbackId):
         self.callbacks.disconnect(callbackId)
 
     def addToView(self, view):
@@ -293,7 +304,7 @@ class TfFrameItem(TfMovableItem):
     def __init__(self, name, transform, frame, view):
 
         TfMovableItem.__init__(self, name, transform, frame, view)
-
+        # transform is the transform of the item in the frame of _frameSync
         self.transform = transformUtils.copyFrame(self.localTransform)
         self.actor.SetUserTransform(self.transform)
 
@@ -377,6 +388,8 @@ class TfFrameItem(TfMovableItem):
         parent = self.parent()
         if (parent and parent.getProperty('Visible')) or self.getProperty('Visible'):
             self._renderAllViews()
+
+        self.callbacks.process('TransformModified', self)
 
     def _onPropertyChanged(self, propertySet, propertyName):
         vis.PolyDataItem._onPropertyChanged(self, propertySet, propertyName)

--- a/src/python/director/visualization.py
+++ b/src/python/director/visualization.py
@@ -108,7 +108,6 @@ class PolyDataItem(om.ObjectModelItem):
 
         array = self.polyData.GetPointData().GetArray(arrayName)
         if not array:
-            print 'colorBy(%s): array not found' % arrayName
             self.mapper.ScalarVisibilityOff()
             self.polyData.GetPointData().SetActiveScalars(None)
             return


### PR DESCRIPTION
@mauricefallon 

This new module subscribes to /aicp/poses and display them.
You can display a pose as a frame or an arrow, you can hide the lines between poses, you also can change the properties of all the lines at the same time if you change the properties of the folder "aicp path/lines".

An /aicp/poses message contains all the poses "computed", I don't redraw the poses already received each time a new message arrives, so I made the assumption that these poses don't change over time. I have created another branch ( draw-aicp-poses ) where this assumption is not made. 

It works with:
https://github.com/ori-drs/director_drs/pull/92