### PR TITLE
Fix director code being installed to incorrect location

### DIFF
--- a/src/app/ddPythonManager.cpp
+++ b/src/app/ddPythonManager.cpp
@@ -62,7 +62,7 @@ void ddPythonManager::preInitialization()
 
   PythonQt::self()->importModule("PythonQt.dd").addObject("_pythonManager", this);
 
-  QString libDir = QFileInfo(QCoreApplication::applicationDirPath() + "/../lib").canonicalFilePath();
+  QString libDir = QFileInfo(QCoreApplication::applicationDirPath() + "/../../lib").canonicalFilePath();
   PythonQtObjectPtr mod = PythonQt::self()->importModule("sys");
   QVariantList version = mod.getVariable("version_info").value<QVariantList>();
   QString pythonMajor = version[0].toString();
@@ -89,7 +89,7 @@ QString ddPythonManager::appSitePackagesDir()
   PythonQtObjectPtr mod = PythonQt::self()->importModule("sys");
   QVariantList version = mod.getVariable("version_info").value<QVariantList>();
 
-  QString sitePath = QString("%1/../lib/python%2.%3/site-packages").arg(
+  QString sitePath = QString("%1/../../lib/python%2.%3/site-packages").arg(
     QCoreApplication::applicationDirPath(),
     version[0].toString(),
     version[1].toString());

--- a/src/python/CMakeLists.txt
+++ b/src/python/CMakeLists.txt
@@ -186,7 +186,7 @@ set(python_files
   )
 
 
-set(python_module_dir "${CATKIN_DEVEL_PREFIX}/lib/${DD_INSTALL_PYTHON_DIR}")
+set(python_module_dir "${CATKIN_DEVEL_PREFIX}/${DD_INSTALL_PYTHON_DIR}")
 
 # Copy python files
 set(copied_python_files)

--- a/src/python/extensions/transformations/CMakeLists.txt
+++ b/src/python/extensions/transformations/CMakeLists.txt
@@ -29,5 +29,5 @@ else()
   set_target_properties(_transformations PROPERTIES PREFIX "" SUFFIX ".so")
 endif()
 
-set_target_properties(_transformations PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CATKIN_DEVEL_PREFIX}/lib/${DD_INSTALL_PYTHON_DIR}/director/thirdparty")
+set_target_properties(_transformations PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CATKIN_DEVEL_PREFIX}/${DD_INSTALL_PYTHON_DIR}/director/thirdparty")
 install(TARGETS _transformations DESTINATION ${DD_INSTALL_PYTHON_DIR}/director/thirdparty)

--- a/src/vtk/DRCFilters/CMakeLists.txt
+++ b/src/vtk/DRCFilters/CMakeLists.txt
@@ -156,6 +156,6 @@ include_directories(${PYTHON_INCLUDE_DIR})
 include(${CMAKE_DIRECTOR_SOURCE_DIR}/cmake/wrap-python.cmake)
 wrap_python(${library_name} "${sources}")
 set_target_properties(${library_name}Python
-  PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CATKIN_DEVEL_PREFIX}/lib/${DD_INSTALL_PYTHON_DIR}/director")
+  PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CATKIN_DEVEL_PREFIX}/${DD_INSTALL_PYTHON_DIR}/director")
 target_link_libraries(${library_name}Python ${PYTHON_LIBRARIES})
 target_link_libraries(${library_name}PythonD ${PYTHON_LIBRARIES})


### PR DESCRIPTION
Code was being installed to `catkin_ws/devel/lib/lib/python2.7/site-packages` due
to duplicated `lib` in the python CMakeLists.txt. `DD_INSTALL_PYTHON_DIR` defined in the main CMakeLists already has `lib` as a prefix. Now installs to
`catkin_ws/devel/lib/python2.7/site-packages`

Same issue for `thirdparty/_transformations.so` and `vtkDRCFiltersPython.so` to the lib/lib directory which were being put there by some other CMakeLists files.