### PR TITLE
fix loading of ply files

### DIFF
--- a/src/python/director/ioUtils.py
+++ b/src/python/director/ioUtils.py
@@ -28,6 +28,8 @@ def readPolyData(filename, computeNormals=False):
     reader.SetFileName(filename)
     reader.Update()
     polyData = shallowCopy(reader.GetOutput())
+    if ext == '.ply':
+        vtk.vtkPCLConversions.AddVertexCells(polyData)
 
     if computeNormals:
         return _computeNormals(polyData)


### PR DESCRIPTION
@mauricefallon 
According to the documentation (https://vtk.org/doc/nightly/html/classvtkPLYReader.html#details): 

> It requires that the elements "vertex" and "face" are defined. The "vertex" element must have the properties "x", "y", and "z". The "face" element must have the property "vertex_indices" defined

The ply files that cannot be loaded don't have this face and vertex_indices properties.
I also followed the fix explained here : https://github.com/RobotLocomotion/director/issues/30
So the solution is to add :

> element face 0
> property list uchar int vertex_indices

just before "end_header" in the ply file that you want to load. I have tested this solution with fsc-oil-rig-map-full-1cm-clipped-height-icp.ply