### PR TITLE
never use LCM in collection

### DIFF
--- a/src/python/director/lcmobjectcollection.py
+++ b/src/python/director/lcmobjectcollection.py
@@ -8,15 +8,8 @@ from director import callbacks
 from director.utime import getUtime
 from director.uuidutil import newUUID
 
-try:
-    import bot_core as lcmbotcore
-    USE_LCM = True
-except ImportError:
-    USE_LCM = False
-
-if USE_LCM:
-    from director import lcmUtils
-
+# TODO remove all references to LCM and USE_LCM
+USE_LCM = False
 
 class LCMObjectCollection(object):
 


### PR DESCRIPTION
the `lcmobjectcollection.py` file automatically sets the variable `USE_LCM` to true if the `lcmbotcore` module is found in the system. This starts a chain reaction of imports that eventually lead to program crash as some LCM modules have been removed from director.

As workaround, this PR sets the variable to False.

In the future, a more throughout eradication of (or separation from) LCM should be performed.