### PR TITLE
Can now add widgets to a submenu of the viewmenu, panels associate with robots

### DIFF
--- a/src/app/ddMainWindow.cpp
+++ b/src/app/ddMainWindow.cpp
@@ -66,6 +66,10 @@ ddMainWindow::ddMainWindow()
   this->setCorner(Qt::BottomLeftCorner, Qt::LeftDockWidgetArea);
   this->setCorner(Qt::BottomRightCorner, Qt::RightDockWidgetArea);
 
+  // This disables right-click context menus for the main window, which show all the dock widgets
+  // Doing this means we don't have to handle enabling/disabling each individual item in the context menu
+  this->setContextMenuPolicy(Qt::NoContextMenu);
+
   //QLabel* logoLabel = new QLabel();
   //logoLabel->setPixmap(QPixmap(":/images/drake_logo.png").scaled(QSize(32,32),  Qt::KeepAspectRatio));
   //logoLabel->setScaledContents(true);
@@ -151,20 +155,20 @@ void ddMainWindow::toggleOutputConsoleVisibility()
 }
 
 //-----------------------------------------------------------------------------
-void ddMainWindow::addWidgetToViewMenu(QWidget* widget)
+void ddMainWindow::addWidgetToViewMenu(QWidget* widget, const QString& subMenuName)
 {
   if (!widget)
   {
     return;
   }
 
-  this->Internal->ViewMenuManager->addWidget(widget, widget->windowTitle());
+  this->Internal->ViewMenuManager->addWidget(widget, widget->windowTitle(), QIcon(), subMenuName);
 }
 
 //-----------------------------------------------------------------------------
-void ddMainWindow::addWidgetToViewMenu(QWidget* widget, QAction* action)
+void ddMainWindow::addWidgetToViewMenu(QWidget* widget, QAction* action, const QString& subMenuName)
 {
-  this->Internal->ViewMenuManager->addWidget(widget, action);
+  this->Internal->ViewMenuManager->addWidget(widget, action, subMenuName);
 }
 
 //-----------------------------------------------------------------------------

--- a/src/app/ddMainWindow.h
+++ b/src/app/ddMainWindow.h
@@ -32,8 +32,8 @@ public:
   QToolBar* panelToolBar() const;
   QTextEdit* outputConsole() const;
 
-  void addWidgetToViewMenu(QWidget* widget);
-  void addWidgetToViewMenu(QWidget* widget, QAction* action);
+  void addWidgetToViewMenu(QWidget* widget, const QString& subMenuName = "");
+  void addWidgetToViewMenu(QWidget* widget, QAction* action, const QString& subMenuName = "");
 
   QList<QAction*> toolBarActions() const;
 

--- a/src/app/ddViewMenu.cpp
+++ b/src/app/ddViewMenu.cpp
@@ -91,7 +91,13 @@ bool ddViewMenu::eventFilter(QObject* watched, QEvent* e)
   return QObject::eventFilter(watched, e);
 }
 
-void ddViewMenu::addWidget(QWidget* widget, QAction* action)
+QMenu* ddViewMenu::addSubMenu(const QString& name) {
+  QMenu* submenu = this->Implementation->Menu.addMenu(name);
+  submenu->setObjectName(name);
+  return submenu;
+}
+
+void ddViewMenu::addWidget(QWidget* widget, QAction* action, const QString& menuName)
 {
   if (this->Implementation->ActionMap.contains(widget))
     {
@@ -117,11 +123,23 @@ void ddViewMenu::addWidget(QWidget* widget, QAction* action)
   this->connect(action, SIGNAL(triggered(bool)), widget, SLOT(setVisible(bool)));
   this->Implementation->ActionMap.insert(widget, action);
   widget->installEventFilter(this);
-  this->Implementation->Menu.addAction(action);
+
+  // Without a specific menu name, add the action to the toplevel menu
+  if (menuName == "") {
+    this->Implementation->Menu.addAction(action);
+  } else {
+    // if the submenu doesn't exist yet, create and then insert the action there
+    QMenu* subMenu = this->Implementation->Menu.findChild<QMenu*>(menuName);
+    if (subMenu == nullptr) {
+      subMenu = addSubMenu(menuName);
+    }
+
+    subMenu->addAction(action);
+  }
 }
 
 
-void ddViewMenu::addWidget(QWidget* widget, const QString& text, const QIcon& icon)
+void ddViewMenu::addWidget(QWidget* widget, const QString& text, const QIcon& icon, const QString& menuName)
 {
   if(this->Implementation->ActionMap.contains(widget))
     {
@@ -141,7 +159,7 @@ void ddViewMenu::addWidget(QWidget* widget, const QString& text, const QIcon& ic
     action->setIcon(icon);
     }
 
-  this->addWidget(widget, action);
+  this->addWidget(widget, action, menuName);
 }
 
 void ddViewMenu::addSeparator()

--- a/src/app/ddViewMenu.h
+++ b/src/app/ddViewMenu.h
@@ -64,6 +64,13 @@ public:
   ///   True if the event should be filtered out.
   virtual bool eventFilter(QObject* watched, QEvent* e);
 
+
+  /// \brief
+  /// Use to add a submenu to the viewmenu
+  /// 
+  /// \param name the name of the submenu, also appears as the label
+  QMenu* addSubMenu(const QString& name);
+
   /// \brief
   ///   Adds a menu item for the widget to the view menu.
   ///
@@ -74,9 +81,10 @@ public:
   /// \param widget The widget to add.
   /// \param icon An icon to display in the menu.
   /// \param text The text to display in the menu.
-  void addWidget(QWidget* widget, const QString& text, const QIcon &icon = QIcon());
+  /// \param subMenuName optional name for a submenu of the view to which this widget should be added
+  void addWidget(QWidget* widget, const QString& text, const QIcon &icon = QIcon(), const QString& subMenuName = "");
 
-  void addWidget(QWidget* widget, QAction* action);
+  void addWidget(QWidget* widget, QAction* action, const QString& menuName = "");
 
   /// Add a separator to the view menu
   void addSeparator();

--- a/src/app/wrapped_methods.txt
+++ b/src/app/wrapped_methods.txt
@@ -25,8 +25,8 @@ QToolBar* ddMainWindow::panelToolBar() const;
 QTreeWidget* ddMainWindow::objectTree() const;
 QTextEdit* ddMainWindow::outputConsole() const;
 QMenu* ddMainWindow::toolsMenu() const;
-void ddMainWindow::addWidgetToViewMenu(QWidget*);
-void ddMainWindow::addWidgetToViewMenu(QWidget*, QAction*);
+void ddMainWindow::addWidgetToViewMenu(QWidget*, const QString&);
+void ddMainWindow::addWidgetToViewMenu(QWidget*, QAction*, const QString&);
 QList<QAction*> ddMainWindow::toolBarActions() const;
 
 ddObjectTree::ddObjectTree();

--- a/src/python/director/affordancepanel.py
+++ b/src/python/director/affordancepanel.py
@@ -121,7 +121,7 @@ def init(view, affordanceManager, jointController):
     global dock
 
     panel = AffordancePanel(view, affordanceManager, jointController)
-    dock = app.addWidgetToDock(panel.widget, action=_getAction())
+    dock = app.addWidgetToDock(panel.widget, action=_getAction(), associatedRobotName=jointController.robotName)
     dock.hide()
 
     return panel

--- a/src/python/director/affordancepanel.py
+++ b/src/python/director/affordancepanel.py
@@ -143,7 +143,9 @@ def init(view, affordanceManager, jointController):
     global dock
 
     panel = AffordancePanel(view, affordanceManager, jointController)
-    dock = app.addWidgetToDock(panel.widget, action=_getAction(), associatedRobotName=jointController.robotName)
+    dock = app.addWidgetToDock(
+        panel.widget, action=_getAction(), associatedRobotName=jointController.robotName
+    )
     dock.hide()
 
     return panel

--- a/src/python/director/applogic.py
+++ b/src/python/director/applogic.py
@@ -113,7 +113,9 @@ def addDockAction(actionName, actionText, iconPath, append=False):
     return action
 
 
-def addWidgetToDock(widget, dockArea=QtCore.Qt.RightDockWidgetArea, action=None, associatedRobotName=""):
+def addWidgetToDock(
+    widget, dockArea=QtCore.Qt.RightDockWidgetArea, action=None, associatedRobotName=""
+):
     """
     This function adds the given widget to the specified dock area. The widgets can then be accesses by clicking the
     icon. It also adds the widgets to the view menu

--- a/src/python/director/applogic.py
+++ b/src/python/director/applogic.py
@@ -114,8 +114,18 @@ def addDockAction(actionName, actionText, iconPath, append=False):
     return action
 
 
-def addWidgetToDock(widget, dockArea=QtCore.Qt.RightDockWidgetArea, action=None):
+def addWidgetToDock(widget, dockArea=QtCore.Qt.RightDockWidgetArea, action=None, associatedRobotName=""):
+    """
+    This function adds the given widget to the specified dock area. The widgets can then be accesses by clicking the
+    icon. It also adds the widgets to the view menu
 
+    :param widget: The widget to add
+    :param dockArea: The dock area to which the widget should be added
+    :param action: The action associated with the widget, which is required for it to work TODO: what is the actual relationship
+    :param associatedRobotName: The name of the robot associated with this action. This is used to set the name of
+    the submenu of the view menu to which this widget will also be added
+    :return:
+    """
     dock = QtGui.QDockWidget()
     dock.setWidget(widget)
     dock.setWindowTitle(widget.windowTitle)
@@ -129,9 +139,9 @@ def addWidgetToDock(widget, dockArea=QtCore.Qt.RightDockWidgetArea, action=None)
         action.connect('triggered()', functools.partial(hideDockWidgets, action))
 
     if action is None:
-        getMainWindow().addWidgetToViewMenu(dock)
+        getMainWindow().addWidgetToViewMenu(dock, associatedRobotName)
     else:
-        getMainWindow().addWidgetToViewMenu(dock, action)
+        getMainWindow().addWidgetToViewMenu(dock, action, associatedRobotName)
 
 
     return dock

--- a/src/python/director/framevisualization.py
+++ b/src/python/director/framevisualization.py
@@ -218,7 +218,9 @@ def init(view, robotSystem):
         panels = {}
 
     panel = FrameVisualizationPanel(view, robotSystem)
-    dock = app.addWidgetToDock(panel.widget, action=None, associatedRobotName=robotSystem.robotName)
+    dock = app.addWidgetToDock(
+        panel.widget, action=None, associatedRobotName=robotSystem.robotName
+    )
     dock.hide()
 
     panels[robotSystem.robotName] = (panel, dock)

--- a/src/python/director/framevisualization.py
+++ b/src/python/director/framevisualization.py
@@ -218,7 +218,7 @@ def init(view, robotSystem):
         panels = {}
 
     panel = FrameVisualizationPanel(view, robotSystem)
-    dock = app.addWidgetToDock(panel.widget, action=None)
+    dock = app.addWidgetToDock(panel.widget, action=None, associatedRobotName=robotSystem.robotName)
     dock.hide()
 
     panels[robotSystem.robotName] = (panel, dock)

--- a/src/python/director/screengrabberpanel.py
+++ b/src/python/director/screengrabberpanel.py
@@ -342,7 +342,7 @@ def init(view, imageWidget, robotName=""):
     action = app.addDockAction('ActionScreenGrabberPanel' + robotName, 'Screen Grabber',
                                os.path.join(os.path.dirname(__file__), 'images/video_record.png'),
                                append=True)
-    dock = app.addWidgetToDock(panel.widget, action=action)
+    dock = app.addWidgetToDock(panel.widget, action=action, associatedRobotName=robotName)
     app.getRobotSelector().associateWidgetWithRobot(action, robotName)
 
     dock.hide()


### PR DESCRIPTION
This helps reduce clutter in cases where multiple robots are being displayed by director

The submenus are greyed out when the robot is not selected to prevent opening of widgets not associated with the currently active robot

Moved some setup in startup.py out of the robotsystem loop as it only has to happen a single time and the rest of the code in the loop does not depend on it

Requires https://github.com/ori-drs/director_drs/pull/134

Partial fix on one of the outstanding issues in https://github.com/ori-drs/drs_base/issues/170, "side panel shows actions"