### PR TITLE
Fix reset time behaviour on sources

### DIFF
--- a/src/python/director/perception.py
+++ b/src/python/director/perception.py
@@ -817,7 +817,7 @@ class MarkerArraySource(vis.PolyDataItemList):
             self.provider._on_property_changed(propertySet, propertyName)
 
     def resetTime(self):
-        self.provider.ResetTime()
+        self.provider.reset_time()
 
     @CheckProvider
     def showData(self):

--- a/src/python/director/perceptionmeta.py
+++ b/src/python/director/perceptionmeta.py
@@ -48,6 +48,14 @@ class SourceMeta(object):
         pass
 
     @abc.abstractmethod
+    def reset_time(self):
+        """
+        Reset the time used by whatever provides the frame transformations
+        :return:
+        """
+        pass
+
+    @abc.abstractmethod
     def _on_property_changed(self, property_set, property_name):
         """
         This function can be used to pass information about changing properties on the object which uses this as a
@@ -90,14 +98,6 @@ class CloudSourceMeta(SourceMeta):
         """
         Set the fixed frame of the provider
         :param fixed_frame: The name of the fixed frame to use
-        :return:
-        """
-        pass
-
-    @abc.abstractmethod
-    def reset_time(self):
-        """
-        Reset the time used by whatever provides the frame transformations
         :return:
         """
         pass
@@ -149,14 +149,6 @@ class ImageSourceMeta(SourceMeta):
         """
         Get a transform between the camera frame and the robot base frame
         :param vtk_transform: This transform will be populated with the transform
-        :return:
-        """
-        pass
-
-    @abc.abstractmethod
-    def reset_time(self):
-        """
-        Reset the time used by whatever provides the frame transformations
         :return:
         """
         pass
@@ -242,14 +234,6 @@ class RosGridMapMeta(SourceMeta):
         """
         Set the fixed frame of the provider
         :param fixed_frame: The name of the fixed frame to use
-        :return:
-        """
-        pass
-
-    @abc.abstractmethod
-    def reset_time(self):
-        """
-        Reset the time used by whatever provides the frame transformations
         :return:
         """
         pass

--- a/src/python/director/robotsystem.py
+++ b/src/python/director/robotsystem.py
@@ -84,7 +84,7 @@ class RobotSystemFactory(object):
         )
 
         # Expand dict to keyword args, robotSystem object will have objects accessible via keys set in config
-        return FieldContainer(**perceptionSources)
+        return FieldContainer(sources=perceptionSources.values(), **perceptionSources)
 
     def initConvexHullModel(self, robotSystem):
 

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -462,17 +462,23 @@ for robotSystem in robotSystems:
     )
 
     # reset time button and connections
-    button = QtGui.QPushButton("Reset time")
-    button.setObjectName("resettime")
+    reset_time_button = QtGui.QPushButton("Reset time")
+    reset_time_button.setObjectName("resettime")
 
-    # Connect reset time button to all sources. Assumes that the source name ends with "source"
-    for name, attr in robotSystem:
-        if str.lower(name).endswith("source"):
-            button.connect("clicked()", attr.resetTime)
+    # Iterate over all sources and reset time when reset button pressed
+    def reset_sources_time():
+        for source in robotSystem.sources:
+            if hasattr(source, "resetTime"):
+                source.resetTime()
 
-    button.connect("clicked()", cameraview.cameraViews[robotSystem.robotName].resetTime)
-    app.getMainWindow().statusBar().addPermanentWidget(button)
-    app.getRobotSelector().associateWidgetWithRobot(button, robotSystem.robotName)
+    reset_time_button.connect("clicked()", reset_sources_time)
+    reset_time_button.connect(
+        "clicked()", cameraview.cameraViews[robotSystem.robotName].resetTime
+    )
+    app.getMainWindow().statusBar().addPermanentWidget(reset_time_button)
+    app.getRobotSelector().associateWidgetWithRobot(
+        reset_time_button, robotSystem.robotName
+    )
 
     useControllerRate = False
     if useControllerRate:

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -471,7 +471,11 @@ for robotSystem in robotSystems:
             if hasattr(source, "resetTime"):
                 source.resetTime()
             else:
-                print("WARNING: source {} does not have a resetTime function. This is probably a mistake.".format(source))
+                print (
+                    "WARNING: source {} does not have a resetTime function. This is probably a mistake.".format(
+                        source
+                    )
+                )
 
     reset_time_button.connect("clicked()", reset_sources_time)
     reset_time_button.connect(

--- a/src/python/director/startup.py
+++ b/src/python/director/startup.py
@@ -470,6 +470,8 @@ for robotSystem in robotSystems:
         for source in robotSystem.sources:
             if hasattr(source, "resetTime"):
                 source.resetTime()
+            else:
+                print("WARNING: source {} does not have a resetTime function. This is probably a mistake.".format(source))
 
     reset_time_button.connect("clicked()", reset_sources_time)
     reset_time_button.connect(


### PR DESCRIPTION
Sources are now held in a list in the robotsystem object so that they can be accessed easily, and they are iterated over to reset time when the reset time button is pressed.

Changed the perceptionmeta sources slightly to reflect a change in vtk ros where now all sources have a reset time function. It being missing was an oversight.

Also fixed an incorrect reset time call in the markerarraysource

Requires https://github.com/ori-drs/director_drs/pull/133 and https://github.com/ori-drs/director_ros/pull/6