### PR TITLE
remove anonymous name of ros node

### DIFF
--- a/src/app/ddROSInit.h
+++ b/src/app/ddROSInit.h
@@ -37,8 +37,7 @@ public:
             }
             int argc = cstrings.size();
 
-            ros::init(argc, cstrings.data(), "director_dd", ros::init_options::NoSigintHandler |
-                        ros::init_options::AnonymousName);
+            ros::init(argc, cstrings.data(), "director_dd", ros::init_options::NoSigintHandler);
         } else {
             ROS_INFO("dd ROS is already initialised.");
         }


### PR DESCRIPTION
@heuristicus 
I don't think that this anonymous name is necessary.
Two ros node are created when director is launched : /director and /director_dd . Do you know where /director is initialized ? I couldn't find it.