### PR TITLE
Correctly kill ros nodes on exit

### DIFF
--- a/src/app/ddMainWindow.cpp
+++ b/src/app/ddMainWindow.cpp
@@ -51,6 +51,7 @@ ddMainWindow::ddMainWindow()
 
   this->Internal->OutputConsoleDock->hide();
   this->connect(this->Internal->ActionMatlabConsole, SIGNAL(triggered()), this, SLOT(toggleOutputConsoleVisibility()));
+  this->connect(QCoreApplication::instance(), SIGNAL(aboutToQuit()), this, SIGNAL(shuttingDown()));
   this->connect(this->Internal->ActionResetCamera, SIGNAL(triggered()), this, SIGNAL(resetCamera()));
   this->connect(this->Internal->ActionToggleStereoRender, SIGNAL(triggered()), this, SIGNAL(toggleStereoRender()));
   this->connect(this->Internal->ActionToggleCameraTerrainMode, SIGNAL(triggered()), this, SIGNAL(toggleCameraTerrainMode()));

--- a/src/app/ddMainWindow.h
+++ b/src/app/ddMainWindow.h
@@ -50,6 +50,7 @@ signals:
   void fileSaveData();
   void fileExportUrdf();
   void openOnlineHelp();
+  void shuttingDown();
 
 
 protected slots:

--- a/src/app/ddROSInit.h
+++ b/src/app/ddROSInit.h
@@ -48,6 +48,10 @@ public:
         spinner->start();
     }
 
+    void ddROSShutdown() {
+        ros::shutdown();
+    }
+
 private:
     std::shared_ptr<ros::AsyncSpinner> spinner;
 };

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -2,11 +2,16 @@
 #include "ddMainWindow.h"
 #include "ddPythonManager.h"
 #include "QVTKOpenGLInit.h"
+#include <signal.h>
 
 #define USE_TDX 0
 #if USE_TDX
   #include <QVTKApplication.h>
 #endif
+
+void signalhandler(int sig){
+  QApplication::instance()->quit();
+}
 
 int main(int argc, char **argv)
 {
@@ -23,6 +28,7 @@ int main(int argc, char **argv)
   window->setPythonManager(pythonManager);
   window->resize(1800, 1000);
   window->show();
+  signal(SIGINT, signalhandler);
 
   int result = app.exec();
 

--- a/src/app/wrapped_methods_ros.txt
+++ b/src/app/wrapped_methods_ros.txt
@@ -3,3 +3,4 @@ ddROSSubscriber::ddROSSubscriber(const QString&, QObject*);
 void ddROSSubscriber::unsubscribe();
 
 ddROSInit::ddROSInit(const QStringList&);
+void ddROSInit::ddROSShutdown();


### PR DESCRIPTION
Progress on fixing https://github.com/ori-drs/drs_base/issues/188.

Need to handle (at least) two possible ways of killing director. First is the window's close button, or alt-f4. This is handled by forwarding the `aboutToQuit` signal through to the python side of director.

The second way of killing is ctrl-c through the terminal which sends a sigint.

Potentially another way of doing it via procman? Not sure which signal that is.

Need https://github.com/ori-drs/director_ros/pull/8 and https://github.com/ori-drs/director_drs/pull/140.