### PR TITLE
Improve starting and stopping of providers

### DIFF
--- a/src/python/director/perception.py
+++ b/src/python/director/perception.py
@@ -627,6 +627,8 @@ class RosGridMap(vis.PolyDataItem):
 
         self.provider = provider
         self.provider.set_consumer(self)
+        if self.getProperty("Visible"):
+            self.provider.start()
 
     def _onPropertyChanged(self, propertySet, propertyName):
         vis.PolyDataItem._onPropertyChanged(self, propertySet, propertyName)
@@ -723,6 +725,8 @@ class MarkerSource(vis.PolyDataItem):
 
         self.provider = provider
         self.provider.set_consumer(self)
+        if self.getProperty("Visible"):
+            self.provider.start()
 
     def _onPropertyChanged(self, propertySet, propertyName):
         vis.PolyDataItem._onPropertyChanged(self, propertySet, propertyName)
@@ -803,6 +807,8 @@ class MarkerArraySource(vis.PolyDataItemList):
 
         self.provider = provider
         self.provider.set_consumer(self)
+        if self.getProperty("Visible"):
+            self.provider.start()
 
     def _onPropertyChanged(self, propertySet, propertyName):
         vis.PolyDataItemList._onPropertyChanged(self, propertySet, propertyName)
@@ -890,6 +896,8 @@ class PointCloudSource(vis.PolyDataItem):
                 decimals=0, minimum=1, maximum=100, singleStep=1, hidden=False
             ),
         )
+        if self.getProperty("Visible"):
+            self.provider.start()
 
     def _onPropertyChanged(self, propertySet, propertyName):
         vis.PolyDataItem._onPropertyChanged(self, propertySet, propertyName)

--- a/src/python/director/perception.py
+++ b/src/python/director/perception.py
@@ -726,16 +726,15 @@ class MarkerSource(vis.PolyDataItem):
 
     def _onPropertyChanged(self, propertySet, propertyName):
         vis.PolyDataItem._onPropertyChanged(self, propertySet, propertyName)
-        if propertyName == "Visible":
+        if propertyName == "Visible" or propertyName == "Subscribe":
             if self.getProperty(propertyName):
                 self.timer.start()
+                if self.provider:
+                    self.provider.start()
             else:
                 self.timer.stop()
-        elif propertyName == "Subscribe":
-            if self.getProperty(propertyName):
-                self.timer.start()
-            else:
-                self.timer.stop()
+                if self.provider:
+                    self.provider.stop()
 
         if self.provider:
             self.provider._on_property_changed(propertySet, propertyName)
@@ -807,16 +806,16 @@ class MarkerArraySource(vis.PolyDataItemList):
 
     def _onPropertyChanged(self, propertySet, propertyName):
         vis.PolyDataItemList._onPropertyChanged(self, propertySet, propertyName)
-        if propertyName == "Visible":
+        if propertyName == "Visible" or propertyName == "Subscribe":
             if self.getProperty(propertyName):
                 self.timer.start()
+                if self.provider:
+                    self.provider.start()
             else:
                 self.timer.stop()
-        elif propertyName == "Subscribe":
-            if self.getProperty(propertyName):
-                self.timer.start()
-            else:
-                self.timer.stop()
+                if self.provider:
+                    self.provider.stop()
+
         if self.provider:
             self.provider._on_property_changed(propertySet, propertyName)
 
@@ -1042,8 +1041,12 @@ class DepthImagePointCloudSource(vis.PolyDataItem):
         if propertyName == "Visible":
             if self.getProperty(propertyName):
                 self.timer.start()
+                if self.provider:
+                    self.provider.start()
             else:
                 self.timer.stop()
+                if self.provider:
+                    self.provider.stop()
 
         if propertyName in ("Decimation", "Remove outliers", "Max Range"):
             self.lastUtime = 0

--- a/src/python/director/perceptionmeta.py
+++ b/src/python/director/perceptionmeta.py
@@ -11,6 +11,7 @@ class SourceMeta(object):
         :param initialisation_object:
         """
         self.consumer = None
+        self.running = False
         self.init_object = initialisation_object
 
     @abc.abstractmethod


### PR DESCRIPTION
Do a check on the visible state of the perception source before starting the provider. This ensures that messages are only pulled from it if the thing is actually being visualised. Should help with bandwidth issues.

Also introduces a running state to the perception meta to ensure that the state of the provider can be checked.

Requires:
- https://github.com/ori-drs/director_ros/pull/11