### PR TITLE
remove director_drs dependency

### DIFF
--- a/src/python/director/__init__.py
+++ b/src/python/director/__init__.py
@@ -15,13 +15,13 @@ def _initCoverage():
 
 def getDRCBaseDir():
     rp = rospkg.RosPack()
-    return rp.get_path("director_drs")
+    return rp.get_path("director")
 
 
 def getDRCBaseIsSet():
     try:
         rp = rospkg.RosPack()
-        rp.get_path("director_drs")
+        rp.get_path("director")
         return True
     except rospkg.ResourceNotFound:
         return False

--- a/src/python/director/__init__.py
+++ b/src/python/director/__init__.py
@@ -15,13 +15,13 @@ def _initCoverage():
 
 def getDRCBaseDir():
     rp = rospkg.RosPack()
-    return rp.get_path("director")
+    return rp.get_path("director_drs")
 
 
 def getDRCBaseIsSet():
     try:
         rp = rospkg.RosPack()
-        rp.get_path("director")
+        rp.get_path("director_drs")
         return True
     except rospkg.ResourceNotFound:
         return False

--- a/src/python/director/applogic.py
+++ b/src/python/director/applogic.py
@@ -390,9 +390,9 @@ def startup(globals):
     global _mainWindow
     _mainWindow = globals["_mainWindow"]
 
-    if not director.getDRCBaseIsSet():
-        showErrorMessage("director package cannot be found")
-        return
+    #if not director.getDRCBaseIsSet():
+    #    showErrorMessage("director_drs package cannot be found")
+    #    return
 
     _mainWindow.connect("resetCamera()", resetCamera)
     _mainWindow.connect("colorCloud()", colorCloud)

--- a/src/python/director/applogic.py
+++ b/src/python/director/applogic.py
@@ -391,7 +391,7 @@ def startup(globals):
     _mainWindow = globals["_mainWindow"]
 
     if not director.getDRCBaseIsSet():
-        showErrorMessage("director_drs package cannot be found")
+        showErrorMessage("director package cannot be found")
         return
 
     _mainWindow.connect("resetCamera()", resetCamera)

--- a/src/python/director/roboturdf.py
+++ b/src/python/director/roboturdf.py
@@ -550,7 +550,7 @@ def _setupPackagePaths():
             PythonQt.dd.ddDrakeModel.addPackageSearchPath(path)
 
 
-_setupPackagePaths()
+#_setupPackagePaths()
 
 
 class HandFactory(object):


### PR DESCRIPTION
This fix is necessary if you want to use director on a computer that doesn't have director_drs. We tested it on Nived's computer.
But it will probably break things if someone wants to keep using director_drs.
I think the name of the DRCBaseDir should be set somewhere instead of being hard-coded. 